### PR TITLE
Add job scheduler to make app run as a long-lived service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - .:/app
       - audio_data:/audio_data
+      - ./data:/app/data
     depends_on:
       db:
         condition: service_healthy
@@ -20,8 +21,8 @@ services:
       - "5001:5000"
     networks:
       - songwriter-network
-    # Simple command to keep container running without errors while in development
-    command: bash -c "python -m songwriter_id || (echo 'App failed to start, staying alive for debugging' && tail -f /dev/null)"
+    # Run in daemon mode with job scheduler
+    command: python -m songwriter_id --daemon --jobs-dir=/app/data/jobs
     restart: on-failure
 
   db:
@@ -51,14 +52,18 @@ services:
     container_name: songwriter-id-ui
     volumes:
       - .:/app
+      - ./data:/app/data
     depends_on:
       db:
         condition: service_healthy
+      app:
+        condition: service_started
     environment:
       - DATABASE_URL=postgresql://songwriter:password@db:5432/songwriter_db
       - FLASK_APP=songwriter_id.review_interface
       - FLASK_ENV=development
       - SECRET_KEY=dev_key_change_in_production
+      - JOB_SCHEDULER_DIR=/app/data/jobs
     ports:
       - "8080:5000"
     networks:

--- a/docs/job_scheduler.md
+++ b/docs/job_scheduler.md
@@ -1,0 +1,111 @@
+# Job Scheduler
+
+This document explains the Job Scheduler system that has been implemented to make the Music Songwriter Credits Identification System run as a long-lived service rather than a one-time batch process.
+
+## Overview
+
+The Job Scheduler is a background process that continually monitors a directory for job specification files. When a new job is detected, it processes the catalog file specified in the job and updates a status file with the results.
+
+## Components
+
+### 1. Main App Daemon Mode
+
+The main application now supports a daemon mode with the `--daemon` flag:
+
+```bash
+python -m songwriter_id --daemon --jobs-dir=/path/to/jobs
+```
+
+When started in daemon mode, the application:
+- Initializes all components (database, API clients, etc.)
+- Starts a job scheduler that monitors the jobs directory
+- Stays running indefinitely, processing jobs as they appear
+
+### 2. Job Scheduler
+
+The `JobScheduler` class in `songwriter_id/scheduler.py` is responsible for:
+- Monitoring the jobs directory for new job files
+- Processing jobs in the background
+- Updating status files with job progress and results
+
+### 3. Review Interface Integration
+
+The web interface has been updated to integrate with the job scheduler:
+- The `JobManager` class in `songwriter_id/review_interface/job_manager.py` provides an interface to the job scheduler
+- The upload form now creates job specification files instead of directly running the pipeline
+- Job status pages now read from the status files created by the job scheduler
+
+## How It Works
+
+### Job Submission Flow
+
+1. A user uploads a catalog file through the web interface
+2. The web interface saves the uploaded file and creates a job specification file (*.job) in the jobs directory
+3. The job scheduler (running in the app container) detects the new job file
+4. The scheduler processes the job and updates a status file (*.status) with progress and results
+5. The web interface monitors the status file to display job progress to the user
+
+### Job File Format
+
+Job specification files (*.job) are JSON files with the following structure:
+
+```json
+{
+  "catalog_path": "/path/to/catalog.csv",
+  "audio_base_path": "/optional/audio/path",
+  "submitted_at": 1618514000.123
+}
+```
+
+### Status File Format
+
+Status files (*.status) are JSON files with the following structure:
+
+```json
+{
+  "status": "running|completed|failed",
+  "start_time": 1618514010.456,
+  "end_time": 1618514020.789,
+  "result": {
+    "import": { /* import statistics */ },
+    "identification": { /* identification statistics */ }
+  }
+}
+```
+
+## Directory Structure
+
+The system uses the following directory structure:
+
+```
+data/
+  jobs/          # Job and status files
+    {job_id}.job      # Job specification
+    {job_id}.status   # Job status and results
+uploads/
+  catalogs/      # Uploaded catalog files
+```
+
+## Configuration
+
+The job scheduler can be configured with:
+
+1. **Docker Compose**: The environment variables in docker-compose.yml
+2. **Command Line**: The `--jobs-dir` flag when running in daemon mode
+3. **Environment Variables**: Set JOB_SCHEDULER_DIR for the review interface
+
+## Benefits
+
+This job scheduling system provides several benefits:
+
+1. **Long-Running Service**: The app now stays alive and processes jobs continuously
+2. **Resilience**: Jobs are persisted as files, so they survive application restarts
+3. **Status Tracking**: Jobs provide detailed status information
+4. **Separation of Concerns**: The web interface submits jobs but doesn't process them directly
+
+## Implementation Details
+
+- The scheduler runs in a background thread within the main app process
+- It polls the jobs directory every few seconds for new job files
+- When a job is processed, the job file is deleted and a status file is created
+- Both containers (app and review-ui) share the jobs directory through a volume mount

--- a/songwriter_id/__main__.py
+++ b/songwriter_id/__main__.py
@@ -2,8 +2,10 @@
 
 import os
 import sys
+import time
 import logging
 import argparse
+import signal
 from dotenv import load_dotenv
 
 # Configure logging
@@ -27,6 +29,10 @@ except ImportError:
 # Import after configure logging
 from songwriter_id.database.setup import setup_database, create_session
 from songwriter_id.pipeline import SongwriterIdentificationPipeline
+from songwriter_id.scheduler import JobScheduler
+
+# Global variable to store the scheduler so it can be stopped on SIGTERM
+scheduler = None
 
 def load_config(config_path):
     """Load configuration from YAML file.
@@ -50,14 +56,35 @@ def load_config(config_path):
         logger.warning(f"Failed to load config file {config_path}: {e}")
         return {}
 
+def signal_handler(sig, frame):
+    """Handle signals like SIGTERM and SIGINT by gracefully shutting down."""
+    global scheduler
+    
+    logger.info(f"Received signal {sig}, shutting down...")
+    
+    if scheduler:
+        logger.info("Stopping job scheduler...")
+        scheduler.stop()
+        
+    logger.info("Shutdown complete.")
+    sys.exit(0)
+
 def main():
     """Main entry point for the application."""
+    global scheduler
+    
     parser = argparse.ArgumentParser(description='Songwriter Identification System')
     parser.add_argument('--config', default='config/pipeline.yaml', help='Path to configuration file')
     parser.add_argument('--catalog', help='Path to catalog CSV file to process')
     parser.add_argument('--audio-path', help='Base path for audio files')
     parser.add_argument('--db-url', help='Database connection URL (overrides environment variable)')
+    parser.add_argument('--daemon', action='store_true', help='Run as a daemon with job scheduler')
+    parser.add_argument('--jobs-dir', default='data/jobs', help='Directory for job files')
     args = parser.parse_args()
+    
+    # Register signal handlers for graceful shutdown
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
     
     # Load environment variables from .env file
     load_dotenv()
@@ -86,18 +113,48 @@ def main():
             db_connection=db_url
         )
         
-        # If catalog provided, process it
+        # If catalog provided, process it directly
         if args.catalog:
             result = pipeline.process_catalog(
                 catalog_path=args.catalog,
                 audio_base_path=args.audio_path
             )
             logger.info(f"Catalog processing complete: {result}")
-        else:
-            logger.info("No catalog provided. System initialized and ready for processing.")
-            # In a real app, this might run a service, API, or wait for jobs
+            return 0
             
-        return 0
+        # If daemon mode is requested, start the job scheduler
+        if args.daemon:
+            logger.info("Starting job scheduler daemon...")
+            
+            # Initialize and start the scheduler
+            scheduler = JobScheduler(pipeline, jobs_dir=args.jobs_dir)
+            scheduler.start()
+            
+            logger.info(f"Job scheduler started and monitoring {args.jobs_dir} for job files")
+            
+            # Loop forever, checking for new jobs
+            try:
+                while True:
+                    # List any active jobs for log monitoring
+                    jobs = scheduler.list_jobs()
+                    running_jobs = [j for j in jobs.values() if j.get('status') == 'running']
+                    
+                    if running_jobs:
+                        logger.info(f"Currently running {len(running_jobs)} jobs")
+                    
+                    # Sleep for a while
+                    time.sleep(60)
+            except KeyboardInterrupt:
+                logger.info("Received keyboard interrupt, shutting down...")
+                scheduler.stop()
+                
+            return 0
+            
+        else:
+            logger.info("No catalog provided and not running in daemon mode. Use --catalog or --daemon.")
+            logger.info("System initialized but exiting. Use --daemon to keep running.")
+            return 0
+            
     except Exception as e:
         logger.error(f"Error in main application: {e}", exc_info=True)
         return 1

--- a/songwriter_id/review_interface/job_manager.py
+++ b/songwriter_id/review_interface/job_manager.py
@@ -1,0 +1,135 @@
+"""Module for handling integration with the job scheduler."""
+
+import os
+import json
+import time
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+class JobManager:
+    """Manager for interacting with the job scheduler from the review interface."""
+    
+    def __init__(self, jobs_dir: str = None):
+        """Initialize the job manager.
+        
+        Args:
+            jobs_dir: Directory for job files
+        """
+        self.jobs_dir = jobs_dir or os.environ.get('JOB_SCHEDULER_DIR', 'data/jobs')
+        self.jobs_path = Path(self.jobs_dir)
+        self.jobs_path.mkdir(parents=True, exist_ok=True)
+        
+    def submit_job(self, catalog_path: str, audio_base_path: Optional[str] = None) -> str:
+        """Submit a new job to the job scheduler.
+        
+        Args:
+            catalog_path: Path to the catalog file
+            audio_base_path: Base path for audio files (optional)
+            
+        Returns:
+            Job ID
+        """
+        import uuid
+        
+        job_id = str(uuid.uuid4())
+        job_file = self.jobs_path / f"{job_id}.job"
+        
+        job_spec = {
+            'catalog_path': catalog_path,
+            'audio_base_path': audio_base_path,
+            'submitted_at': time.time(),
+            'created_at': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        }
+        
+        with open(job_file, 'w') as f:
+            json.dump(job_spec, f)
+            
+        logger.info(f"Submitted job {job_id} to process catalog {catalog_path}")
+        return job_id
+        
+    def get_job_status(self, job_id: str) -> Dict[str, Any]:
+        """Get the status of a job.
+        
+        Args:
+            job_id: Job ID
+            
+        Returns:
+            Job status information
+        """
+        status_file = self.jobs_path / f"{job_id}.status"
+        job_file = self.jobs_path / f"{job_id}.job"
+        
+        # Check if job exists
+        if not status_file.exists() and not job_file.exists():
+            return {'status': 'not_found', 'job_id': job_id}
+            
+        # If job file exists but no status file, it's pending
+        if job_file.exists() and not status_file.exists():
+            try:
+                with open(job_file, 'r') as f:
+                    job_spec = json.load(f)
+                    
+                return {
+                    'status': 'pending',
+                    'job_id': job_id,
+                    'submitted_at': job_spec.get('submitted_at', time.time()),
+                    'created_at': job_spec.get('created_at', datetime.now().strftime('%Y-%m-%d %H:%M:%S')),
+                    'catalog_path': job_spec.get('catalog_path', '')
+                }
+            except Exception as e:
+                logger.error(f"Error reading job file {job_file}: {e}")
+                return {'status': 'error', 'job_id': job_id, 'error': str(e)}
+        
+        # If status file exists, read it
+        if status_file.exists():
+            try:
+                with open(status_file, 'r') as f:
+                    status = json.load(f)
+                    status['job_id'] = job_id
+                    return status
+            except Exception as e:
+                logger.error(f"Error reading status file {status_file}: {e}")
+                return {'status': 'error', 'job_id': job_id, 'error': str(e)}
+                
+        return {'status': 'unknown', 'job_id': job_id}
+        
+    def list_jobs(self, limit: int = None) -> List[Dict[str, Any]]:
+        """List all jobs and their statuses.
+        
+        Args:
+            limit: Optional limit on the number of jobs to return
+            
+        Returns:
+            List of job status dictionaries
+        """
+        jobs = []
+        
+        # Get all job and status files
+        job_files = list(self.jobs_path.glob('*.job'))
+        status_files = list(self.jobs_path.glob('*.status'))
+        
+        # Process all job files
+        job_ids = set()
+        for job_file in job_files:
+            job_id = job_file.stem
+            job_ids.add(job_id)
+            jobs.append(self.get_job_status(job_id))
+            
+        # Process status files not already covered
+        for status_file in status_files:
+            job_id = status_file.stem
+            if job_id not in job_ids:
+                jobs.append(self.get_job_status(job_id))
+                
+        # Sort by submitted_at (most recent first)
+        jobs.sort(key=lambda x: x.get('submitted_at', 0), reverse=True)
+        
+        # Apply limit if specified
+        if limit is not None and limit > 0:
+            jobs = jobs[:limit]
+                
+        return jobs

--- a/songwriter_id/scheduler.py
+++ b/songwriter_id/scheduler.py
@@ -1,0 +1,222 @@
+"""Job scheduler for processing catalog jobs in the background."""
+
+import os
+import threading
+import time
+import logging
+import json
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+class JobScheduler:
+    """Simple job scheduler for processing catalogs in the background."""
+    
+    def __init__(self, pipeline, jobs_dir: str = 'data/jobs'):
+        """Initialize the job scheduler.
+        
+        Args:
+            pipeline: Initialized SongwriterIdentificationPipeline
+            jobs_dir: Directory for job files
+        """
+        self.pipeline = pipeline
+        self.jobs_dir = Path(jobs_dir)
+        self.jobs_dir.mkdir(parents=True, exist_ok=True)
+        self.active_jobs = {}
+        self.polling_thread = None
+        self.running = False
+        
+    def start(self):
+        """Start the job scheduler."""
+        if self.polling_thread and self.polling_thread.is_alive():
+            logger.warning("Job scheduler already running")
+            return
+            
+        self.running = True
+        self.polling_thread = threading.Thread(target=self._polling_loop)
+        self.polling_thread.daemon = True
+        self.polling_thread.start()
+        logger.info("Job scheduler started")
+        
+    def stop(self):
+        """Stop the job scheduler."""
+        self.running = False
+        if self.polling_thread:
+            self.polling_thread.join(timeout=5)
+        logger.info("Job scheduler stopped")
+        
+    def submit_job(self, catalog_path: str, audio_base_path: Optional[str] = None) -> str:
+        """Submit a new job to process a catalog.
+        
+        Args:
+            catalog_path: Path to the catalog file
+            audio_base_path: Base path for audio files (optional)
+            
+        Returns:
+            Job ID
+        """
+        import uuid
+        
+        job_id = str(uuid.uuid4())
+        job_file = self.jobs_dir / f"{job_id}.job"
+        
+        job_spec = {
+            'catalog_path': catalog_path,
+            'audio_base_path': audio_base_path,
+            'submitted_at': time.time()
+        }
+        
+        with open(job_file, 'w') as f:
+            json.dump(job_spec, f)
+            
+        logger.info(f"Submitted job {job_id} to process catalog {catalog_path}")
+        return job_id
+        
+    def get_job_status(self, job_id: str) -> Dict[str, Any]:
+        """Get the status of a job.
+        
+        Args:
+            job_id: Job ID
+            
+        Returns:
+            Job status information
+        """
+        status_file = self.jobs_dir / f"{job_id}.status"
+        job_file = self.jobs_dir / f"{job_id}.job"
+        
+        # Check if job exists
+        if not status_file.exists() and not job_file.exists():
+            return {'status': 'not_found', 'job_id': job_id}
+            
+        # If job file exists but no status file, it's pending
+        if job_file.exists() and not status_file.exists():
+            try:
+                with open(job_file, 'r') as f:
+                    job_spec = json.load(f)
+                    
+                return {
+                    'status': 'pending',
+                    'job_id': job_id,
+                    'submitted_at': job_spec.get('submitted_at', time.time()),
+                    'catalog_path': job_spec.get('catalog_path', '')
+                }
+            except Exception as e:
+                logger.error(f"Error reading job file {job_file}: {e}")
+                return {'status': 'error', 'job_id': job_id, 'error': str(e)}
+        
+        # If status file exists, read it
+        if status_file.exists():
+            try:
+                with open(status_file, 'r') as f:
+                    status = json.load(f)
+                    status['job_id'] = job_id
+                    return status
+            except Exception as e:
+                logger.error(f"Error reading status file {status_file}: {e}")
+                return {'status': 'error', 'job_id': job_id, 'error': str(e)}
+                
+        return {'status': 'unknown', 'job_id': job_id}
+        
+    def list_jobs(self) -> Dict[str, Dict[str, Any]]:
+        """List all jobs and their statuses.
+        
+        Returns:
+            Dictionary of job IDs and their statuses
+        """
+        jobs = {}
+        
+        # Get all job and status files
+        job_files = list(self.jobs_dir.glob('*.job'))
+        status_files = list(self.jobs_dir.glob('*.status'))
+        
+        # Process pending jobs
+        for job_file in job_files:
+            job_id = job_file.stem
+            jobs[job_id] = self.get_job_status(job_id)
+            
+        # Process jobs with status
+        for status_file in status_files:
+            job_id = status_file.stem
+            if job_id not in jobs:
+                jobs[job_id] = self.get_job_status(job_id)
+                
+        return jobs
+        
+    def _polling_loop(self):
+        """Main polling loop to check for new jobs."""
+        while self.running:
+            # Look for job files
+            job_files = list(self.jobs_dir.glob('*.job'))
+            
+            for job_file in job_files:
+                try:
+                    # Load job specification
+                    with open(job_file, 'r') as f:
+                        job_spec = json.load(f)
+                        
+                    # Create status file to mark job as in progress
+                    job_id = job_file.stem
+                    status_file = job_file.with_suffix('.status')
+                    with open(status_file, 'w') as f:
+                        json.dump({
+                            'status': 'running',
+                            'start_time': time.time()
+                        }, f)
+                        
+                    # Remove job file to prevent reprocessing
+                    job_file.unlink()
+                    
+                    # Process the job
+                    self._process_job(job_id, job_spec, status_file)
+                    
+                except Exception as e:
+                    logger.error(f"Error processing job file {job_file}: {e}")
+                    
+            # Sleep before next check
+            time.sleep(5)
+            
+    def _process_job(self, job_id: str, job_spec: Dict[str, Any], status_file: Path):
+        """Process a single job.
+        
+        Args:
+            job_id: Job ID
+            job_spec: Job specification
+            status_file: Path to the status file
+        """
+        logger.info(f"Processing job {job_id}")
+        
+        try:
+            # Extract job parameters
+            catalog_path = job_spec.get('catalog_path')
+            audio_base_path = job_spec.get('audio_base_path')
+            
+            if not catalog_path or not os.path.exists(catalog_path):
+                raise ValueError(f"Invalid catalog path: {catalog_path}")
+                
+            # Process the catalog
+            result = self.pipeline.process_catalog(
+                catalog_path=catalog_path,
+                audio_base_path=audio_base_path
+            )
+            
+            # Update status file with result
+            with open(status_file, 'w') as f:
+                json.dump({
+                    'status': 'completed',
+                    'result': result,
+                    'end_time': time.time()
+                }, f)
+                
+            logger.info(f"Job {job_id} completed successfully")
+            
+        except Exception as e:
+            logger.error(f"Error processing job {job_id}: {e}")
+            
+            # Update status file with error
+            with open(status_file, 'w') as f:
+                json.dump({
+                    'status': 'failed',
+                    'error': str(e),
+                    'end_time': time.time()
+                }, f)


### PR DESCRIPTION
## Job Scheduler Implementation

This PR implements a job scheduler system that allows the Music Songwriter Credits Identification System to run as a long-lived service rather than exiting after initialization when no catalog is provided.

### Changes

1. **Added a Job Scheduler**
   - New `JobScheduler` class in `songwriter_id/scheduler.py`
   - Background thread monitors a directory for job files
   - Processes jobs and updates status files

2. **Updated Main Entry Point**
   - Added `--daemon` flag to run in job scheduler mode
   - Implemented signal handling for graceful shutdown
   - Added job directory configuration

3. **Integrated with Review Interface**
   - Added `JobManager` class for the web interface
   - Updated catalog upload to submit jobs to the scheduler
   - Updated job status pages to read status files

4. **Updated Docker Configuration**
   - Modified docker-compose.yml to run app in daemon mode
   - Added shared volume for job files
   - Added appropriate environment variables

### How to Use

1. Start the application in daemon mode:
   ```
   docker-compose up
   ```

2. Upload a catalog file through the web interface (http://localhost:8080/pipeline)

3. The job will be automatically processed by the app container

4. View job status and results on the web interface

### Documentation

See `docs/job_scheduler.md` for detailed information about the job scheduler system.